### PR TITLE
Save Lists to DB Instead of a File

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ Sort Settings
 '-ns', '--nosort' - 'Do not sort the output from the search (defaults to false).'
 '-spt', '--startpt' - 'Specify the line index as an int of the coordinate you want TSP to keep as the starting point (defaults to None).'
 '-fpt', '--finishpt' - 'Specify the line index as an int of the coordinate you want TSP to keep as the finishing point (defaults to None).'
+
+Saving to the DB Settings
+These settings are all optional and update the DB instead of outputting to a file when used.
+'-squ', '--save-query' - 'Save the query results to the DB and requires the below options (defaults to false).'
+'-sbe', '--save-backend' - 'URL to RDM site (defaults to http://127.0.0.1:9000/).'
+'-sun', '--save-un' - 'Username for the RDM site (no default).'
+'-spw', '--save-pw' - 'Password for the RDM site (no default).'
+'-siv', '--save-iv' - 'The name of the IV instance(s) to save the list to. ALL for all IV instances, one name, or multiple names separated by commas like "IV1, IV2", use the quotes. (defaults to ALL).'
+'-scp', '--save-cp' - 'The name of the Circle Pokemon/Raid instance(s) to save the list to. One name or multiple names separated by commas like "Poke1, Poke2", use the quotes. When using multiple instances, the list will be split evenly between them. (defaults to none).'
 ```
 
 You must specify an instance to use in the `geofence` parameter so the script can search for it. Instances with multiple geofences are acceptable. The script will read and apply each geofence to the query.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ S2Cell Settings
 IV List Settings
 No cluster options will be recognized for the below options.
 '-giv', '--genivlist' - 'Skip all the normal functionality and just generate an IV list using RDM data (defaults to false).'
-'-mp', '--maxpoke' - 'The maximum number to be used for the end of the IV list (defaults to 809).'
+'-mp', '--maxpoke' - 'The maximum number to be used for the end of the IV list (defaults to 890).'
 '--excludepoke' - 'List of Pokemon to exclude from the IV list. Specified as Pokemon ID. Use this only in the config file (defaults to none).'
 '-d', '--days' - 'Only include data from x days in the IV list's query. 0 for today, 1 for yesterday & today, etc. (defaults to 7).'
 

--- a/cluster.py
+++ b/cluster.py
@@ -1,4 +1,4 @@
-import configargparse,time,sys,os,peewee,json,numpy,matplotlib,geopy,s2sphere,multiprocessing
+import configargparse,time,sys,os,peewee,json,numpy,matplotlib,geopy,s2sphere,multiprocessing,requests
 from math import radians, sin, cos, acos, sqrt
 from tsp_solver import solve_tsp
 from geopy import distance
@@ -522,14 +522,63 @@ def genivs(args):
             if int(idex) in datajson:
                 datajson.remove(int(idex))
 
-        # Write output to a file
-        filename = str(args.output)
-        f = open(filename, 'w')
+        if args.save_query:
+            # Write information to the DB.
+            wasALL = False # Track this so we limit the queries later
+            instances = args.save_iv.split(", ")
+            if instances == ['ALL']:
+                # Get a list of all IV instannces
+                wasALL = True
+                cmd_sql = '''SELECT name FROM instance WHERE type = 'pokemon_iv';'''
+                intALLivs = db.execute_sql(cmd_sql)
+                intALLivssql = intALLivs.fetchall()
+                instances = []
+                for row in intALLivssql:
+                    instances.append(row[0])
 
-        for d in datajson:
-            f.write(str(d)+'\n')
-        f.close()
-        print('IV list written to the {} file.'.format(filename))
+            for instance in instances:
+                if not wasALL:
+                    cmd_sql = '''SELECT type FROM instance WHERE name = '%s';''' % instance
+                    inttype = db.execute_sql(cmd_sql)
+                    inttypesql = inttype.fetchone()
+
+                    try:
+                        temp = inttypesql[0] # Get the first item in the tuple and convert it to json
+                    except:
+                        print('No instance found with name {}.'.format(instance))
+                        sys.exit(1)
+
+                if wasALL or inttypesql[0] == 'pokemon_iv':
+                    print('Updating IV pokemon list for {}.'.format(instance))
+                    cmd_sql = '''UPDATE instance SET data = JSON_SET(data, '$.pokemon_ids', JSON_ARRAY(%(ids)s)) WHERE name = '%(ins)s';''' % {'ids':str(datajson).replace('[', '').replace(']', ''), 'ins': instance}
+                    updateOutput = db.execute_sql(cmd_sql)
+                    db.commit()
+                else:
+                    print('{} is not an IV instance.'.format(instance))
+                    sys.exit(1)
+
+            print('IV list saved to the database.\n')
+
+            # Use RDM API to restart all instances
+            print('Restarting RDM instances.')
+            resp = requests.get(args.save_backend+"api/get_data?reload_instances=true", auth=(args.save_un,args.save_pw))
+            try:
+                data = resp.json()
+            except:
+                data = str(resp)
+            print('Site response: {}\n'.format(data))
+        else:
+            # Write output to a file
+            filename = str(args.output)
+            f = open(filename, 'w')
+
+            for d in datajson:
+                f.write(str(d)+'\n')
+            f.close()
+            print('IV list written to the {} file.\n'.format(filename))
+
+    db.close()
+    print('Database connection closed')
 
 def createcircles(args):
     print('Connecting to MySQL database {} on {}:{}...\n'.format(args.db_name, args.db_host, args.db_port))
@@ -720,7 +769,7 @@ if __name__ == "__main__":
 
     ivl = parser.add_argument_group('IV List',description='No cluster options will be recognized for the below options.')
     ivl.add_argument('-giv', '--genivlist', help='Skip all the normal functionality and just generate an IV list using RDM data (defaults to false).', action='store_true', default=False)
-    ivl.add_argument('-mp', '--maxpoke', type=int, help='The maximum number to be used for the end of the IV list (defaults to 809).', default=809)
+    ivl.add_argument('-mp', '--maxpoke', type=int, help='The maximum number to be used for the end of the IV list (defaults to 890).', default=890)
     ivl.add_argument('--excludepoke', help=('List of Pokemon to exclude from the IV list. Specified as Pokemon ID. Use this only in the config file (defaults to none).'), action='append', default=[])
     ivl.add_argument('-d', '--days', help='Only include data from x days in the IV list\'s query. 0 for today, 1 for yesterday & today, etc. (defaults to 7).', default=7)
 
@@ -737,9 +786,21 @@ if __name__ == "__main__":
     sort.add_argument('-spt', '--startpt', type=int, help='Specify the line index as an int of the coordinate you want TSP to keep as the starting point (defaults to None).', default=None)
     sort.add_argument('-fpt', '--finishpt', type=int, help='Specify the line index as an int of the coordinate you want TSP to keep as the finishing point (defaults to None).', default=None)
 
+    save = parser.add_argument_group('Saving to the DB Settings',description='These settings are all optional and update the DB instead of outputting to a file when used.')
+    save.add_argument('-squ', '--save-query', help='Save the query results to the DB and requires the below options (defaults to false).', action='store_true', default=False)
+    save.add_argument('-sbe', '--save-backend', help='URL to RDM site (defaults to http://127.0.0.1:9000/).', default='http://127.0.0.1:9000/')
+    save.add_argument('-sun', '--save-un', help='Username for the RDM site (no default).')
+    save.add_argument('-spw', '--save-pw', help='Password for the RDM site (no default).')
+    save.add_argument('-siv', '--save-iv', help='The name of the IV instance(s) to save the list to. ALL for all IV instances, one name, or multiple names separated by commas like \"IV1, IV2\", use the quotes. (defaults to ALL).', default='ALL')
+    save.add_argument('-scp', '--save-cp', help='The name of the Circle Pokemon/Raid instance(s) to save the list to. One name or multiple names separated by commas like \"Poke1, Poke2\", use the quotes. When using multiple instances, the list will be split evenly between them. (defaults to none).')
+
     args = parser.parse_args()
 
     if args.genivlist:
+        if args.save_query:
+            if not args.save_un or not args.save_pw:
+                print('You must specify both a site username and password to continue with saving to the database.')
+                sys.exit(1)
         genivs(args)
         sys.exit(1)
     if args.justsort:
@@ -754,15 +815,31 @@ if __name__ == "__main__":
         print('You must specify a geofence to continue.')
         sys.exit(1)
     if args.circle:
+        if args.save_query:
+            if not args.save_un or not args.save_pw:
+                print('You must specify both a site username and password to continue with saving to the database.')
+                sys.exit(1)
+            if not args.save_cp:
+                print('You must specify at least one instance to save to.')
+                sys.exit(1)
         createcircles(args)
         sys.exit(1)
     if not args.spawnpoints and not args.pokestops and not args.gyms and not args.s2cells:
         print('You must choose to include either spawnpoints, gyms, pokestops, or S2Cells for the query.')
         sys.exit(1)
+    if args.spawnpoints or args.pokestops or args.gyms or args.s2cells:
+        if args.save_query:
+            if not args.save_un or not args.save_pw:
+                print('You must specify both a site username and password to continue with saving to the database.')
+                sys.exit(1)
+            if not args.save_cp:
+                print('You must specify at least one instance to save to.')
+                sys.exit(1)
 
     main(args)
 
 # Maybe use the RDM API to write to an instance after the coordinates are sorted
+#   For clusters/cc, specifying multiple instances should split the clusters
 # Maybe add a geofence generator. If a geofence is generated, read it from the file to use it for clustering?
 
 # As reported by Hunch. He got this warning with MySQL 5.7

--- a/config.ini.example
+++ b/config.ini.example
@@ -31,7 +31,7 @@
 #IV List Settings
 # No cluster options will be recognized for the below options.
 #genivlist                      # Skip all the normal functionality and just generate an IV list using RDM data (defaults to false).
-#maxpoke:                       # The maximum number to be used for the end of the IV list (defaults to 809).
+#maxpoke:                       # The maximum number to be used for the end of the IV list (defaults to 890).
 #excludepoke:                   # List of Pokemon to exclude from the IV list. Specified as Pokemon ID. Use this only in the config file (defaults to none).
 #days:                          # Only include data from x days in the IV list's query. 0 for today, 1 for yesterday & today, etc. (defaults to 7).
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -49,3 +49,12 @@
 #nosort                         # Do not sort the output from the search (defaults to false).
 #startpt:                       # Specify the line index as an int of the coordinate you want TSP to keep as the starting point (defaults to None).
 #finishpt:                      # Specify the line index as an int of the coordinate you want TSP to keep as the finishing point (defaults to None).
+
+#Saving to the DB Settings
+# These settings are all optional and update the DB instead of outputting to a file when used.
+#save-query                     # Save the query results to the DB and requires the below options (defaults to false).
+#save-backend:                   # URL to RDM site (defaults to http://127.0.0.1:9000/).
+#save-un:                        # Username for the RDM site (no default).
+#save-pw:                        # Password for the RDM site (no default).
+#save-iv:                        # The name of the IV instance(s) to save the list to. ALL for all IV instances, one name, or multiple names separated by commas like "IV1, IV2", use the quotes. (defaults to ALL).
+#save-cp:                        # The name of the Circle Pokemon/Raid instance(s) to save the list to. One name or multiple names separated by commas like "Poke1, Poke2", use the quotes. When using multiple instances, the list will be split evenly between them. (defaults to none).


### PR DESCRIPTION
This update includes functionality to save the generated lists to the RDM database instead of outputting it to a file. Afterwards, it uses an API to reload the instances in RDM so the changes are recognized without restarting the container.

WIP for saving the "create circles" option and clusters. Currently works for generated IV lists if you compile RDM [PR#231](https://github.com/RealDeviceMap/RealDeviceMap/pull/231) or by manually restarting the container afterwards. 